### PR TITLE
Removed php version requirement from composer and defined default scope value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
   "keywords": ["yii2", "authclient", "oauth", "gitlab"],
   "homepage": "http://github.com/yiiauth/gitlab",
   "require": {
-    "php": "^7.0",
     "yiisoft/yii2-authclient": "~2.1"
   },
   "license": "MIT",

--- a/src/GitLabClient.php
+++ b/src/GitLabClient.php
@@ -48,7 +48,10 @@ class GitLabClient extends OAuth2
      * {@inheritdoc}
      */
     public $apiBaseUrl = '/api/v4/';
-
+    /**
+     * {@inheritdoc}
+     */
+    public $scope = 'read_user';
     /**
      * Domain instance gitlab
      * @var string
@@ -62,7 +65,7 @@ class GitLabClient extends OAuth2
     public function init()
     {
         parent::init();
-        
+
         $this->authUrl    = $this->domain.$this->authUrl;
         $this->tokenUrl   = $this->domain.$this->tokenUrl;
         $this->apiBaseUrl = $this->domain.$this->apiBaseUrl;


### PR DESCRIPTION
The `yiisoft/yii2-authclient` and `yiisoft/yii2-httpclient` packages don''t have minimum PHP version requirement (it is "inherited" from the main yii2 repo that currently requires 5.4+).